### PR TITLE
Fix API build issues

### DIFF
--- a/api/api.csproj
+++ b/api/api.csproj
@@ -4,12 +4,13 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.2.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.37" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.41" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.5.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/web.test/web.test.csproj
+++ b/web.test/web.test.csproj
@@ -7,12 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.33.0" />
+    <PackageReference Include="bunit" Version="1.33.3" />
     <PackageReference Include="fluentassertions" Version="6.12.1" />
     <PackageReference Include="moq" Version="4.20.71" />
     <PackageReference Include="NUnit" Version="4.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- api.csproj: Updated Microsoft.AspNetCore.Mvc to 2.3.0 (10.0.0 doesn't exist)
- api.csproj: Fixed package downgrade conflict by upgrading Microsoft.Azure.WebJobs from 3.0.37 to 3.0.42
- api.csproj: Updated Microsoft.Azure.WebJobs.Extensions from 5.2.0 to 5.2.1
- api.csproj: Updated Microsoft.Azure.WebJobs.Logging.ApplicationInsights from 3.0.37 to 3.0.41
- api.csproj: Added explicit System.Drawing.Common 8.0.0 to fix critical vulnerability in 4.7.0
- web.test.csproj: Updated bunit from 1.33.0 to 1.33.3
- web.test.csproj: Updated NUnit3TestAdapter from 4.6.3 to 5.0.0
- web.test.csproj: Added explicit Microsoft.Extensions.Caching.Memory 10.0.0 to replace vulnerable pre-release version

All projects now build with zero warnings and tests pass successfully